### PR TITLE
Removing requirement for pycurl, as discussed over email, as it creates ...

### DIFF
--- a/requirements.pip
+++ b/requirements.pip
@@ -3,4 +3,3 @@
 nose==1.1.2
 unittest2==0.5.1
 simplejson==2.2.1
-pycurl


### PR DESCRIPTION
...an unnecessary burden for getting hapi up and running.
