### PR TITLE
adding hapi.mixins to packages list (missing from python egg otherwise)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     url='https://github.com/HubSpot/hapipy',
     download_url='https://github.com/HubSpot/hapipy/tarball/v2.7.6',
     license='LICENSE.txt',
-    packages=['hapi'],
+    packages=['hapi', 'hapi.mixins'],
     install_requires=[
         'nose==1.1.2',
         'unittest2==0.5.1',


### PR DESCRIPTION
need this to get Deploy 2.0 to work... also if anyone tried to make a python egg out of this package in the past, it didn't include anything in hapi.mixins...
