### PR TITLE
change method to allow setting max and fix spelling error

### DIFF
--- a/hapi/test/test_blog.py
+++ b/hapi/test/test_blog.py
@@ -58,6 +58,18 @@ class BlogClientTest(unittest2.TestCase):
         blogs = self.client.get_blogs()
         blog = blogs[0]
         
+        blog_posts = self.client.get_published_posts(blog['guid'])
+        self.assertTrue(len(blog_posts) > 2)
+
+        two_blog_posts = self.client.get_published_posts(blog['guid'], max=2)
+        self.assertEquals(len(two_blog_posts), 2)
+        print "Got some published blog posts from the blog: %s" % json.dumps(blog_posts)
+
+    @attr('api')
+    def test_get_pulished_posts(self):
+        blogs = self.client.get_blogs()
+        blog = blogs[0]
+        
         blog_posts = self.client.get_pulished_posts(blog['guid'])
         self.assertTrue(len(blog_posts))
         print "Got some published blog posts from the blog: %s" % json.dumps(blog_posts)


### PR DESCRIPTION
Method "get_pulished_posts" did not honor the passed in query params (like max / offset -- http://developers.hubspot.com/docs/methods/blog/get_posts).

Added a new method get_published_posts that fixes the original typo and supports params. Included a test that setting "max" is respected.
