### PR TITLE
add gzip accepts header and handle uncompress on response

### DIFF
--- a/hapi/base.py
+++ b/hapi/base.py
@@ -7,7 +7,7 @@ import sys
 import time
 import traceback
 import gzip
-import io
+import StringIO
 
 from error import HapiError, HapiBadRequest, HapiNotFound, HapiTimeout, HapiServerError
 
@@ -115,8 +115,8 @@ class BaseClient(object):
     def _digest_result(self, data, gzipped=False):
 
         if gzipped:
-            bi = io.BytesIO(data)
-            gf = gzip.GzipFile(fileobj=bi, mode="rb")
+            sio = StringIO.StringIO(data)
+            gf = gzip.GzipFile(fileobj=sio, mode="rb")
             gdata = gf.read()
             data = gdata
 

--- a/hapi/test/test_base.py
+++ b/hapi/test/test_base.py
@@ -1,5 +1,8 @@
 from collections import defaultdict
 import unittest2
+import simplejson as json
+from StringIO import StringIO
+from gzip import GzipFile
 
 from hapi.base import BaseClient
 from hapi.error import HapiError
@@ -82,3 +85,24 @@ class BaseTest(unittest2.TestCase):
             raised_error = True
         self.assertTrue(raised_error)
 
+    def test_digest_result(self):
+        """
+        Test parsing returned data in various forms
+        """
+        plain_text = "Hello Plain Text"
+        data = self.client._digest_result(plain_text, False)
+        self.assertEquals(plain_text, data)
+
+        raw_json = '{"hello": "json"}'
+        data = self.client._digest_result(raw_json, False)
+        # Should parse as json into dict
+        self.assertEquals(data.get('hello'), 'json')
+
+        # Write our data into a gzipped stream
+        sio = StringIO()
+        gzf = GzipFile(fileobj=sio, mode='wb')
+        gzf.write('{"hello": "gzipped"}')
+        gzf.close()
+
+        data = self.client._digest_result(sio.getvalue(), True)
+        self.assertEquals(data.get('hello'), 'gzipped')


### PR DESCRIPTION
While investigating an issue this morning with truncated response bodies we noticed that hapi isn't requesting responses be compressed. Added default support for requesting response be gzip'd and ungzipping the body based on response headers.

All the tests continue to pass (with exception of a Prospects API test). 

Feedback appreciated.
