### PR TITLE
fix api url in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@
 
 A python wrapper around HubSpot's APIs. Docs for this wrapper can be found [here](https://github.com/HubSpot/hapipy/wiki/hapipy-documentation).
 
-General API reference documentation can be found [here](http://docs.hubapi.com">http://docs.hubapi.com).
+General API reference documentation can be found [here](http://developers.hubspot.com/docs/overview).


### PR DESCRIPTION
Had spurrious characters and was also outdated.