### PR TITLE
Remove nose and unittest2 from install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,6 @@ setup(
     license='LICENSE.txt',
     packages=['hapi', 'hapi.mixins'],
     install_requires=[
-        'nose==1.2.1',
-        'unittest2==0.5.1',
         'simplejson>=2.1.2'
     ],
 )


### PR DESCRIPTION
Test / development requirements shouldn't be required for people who simply want to install the package.

These are still kept in requirements.pip, in case someone wants to run the tests locally.
